### PR TITLE
remove override to allow compatibility with RN 0.47

### DIFF
--- a/android/src/main/java/com/mikemonteith/reactnativeandroidcheckbox/CheckboxPackage.java
+++ b/android/src/main/java/com/mikemonteith/reactnativeandroidcheckbox/CheckboxPackage.java
@@ -24,7 +24,6 @@ public class CheckboxPackage implements ReactPackage {
         );
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Arrays.asList();
     }


### PR DESCRIPTION
createJSModules is now not required on Android from RN 0.47.

cannot currently build app because of the `@overide` marker

quickest fix is to just take it out as this maintains backwards compatibility